### PR TITLE
Fix: Do not require codecov to pass

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -10,8 +10,6 @@ branches:
         required_approving_review_count: 1
       required_status_checks:
         contexts:
-          - "codecov/patch"
-          - "codecov/project"
           - "Travis CI - Branch"
           - "Travis CI - Pull Request"
         strict: false


### PR DESCRIPTION
This PR

* [x] removes the requirement for codecov.io to pass

💁‍♂ After all, we do not collect coverage (we can't, we only have interfaces).