### PR TITLE
Fix: Remove non-standard PURGE method

### DIFF
--- a/src/Method.php
+++ b/src/Method.php
@@ -22,7 +22,6 @@ interface Method
     public const OPTIONS = 'OPTIONS';
     public const PATCH = 'PATCH';
     public const POST = 'POST';
-    public const PURGE = 'PURGE';
     public const PUT = 'PUT';
     public const TRACE = 'TRACE';
 }

--- a/test/Unit/MethodTest.php
+++ b/test/Unit/MethodTest.php
@@ -32,7 +32,6 @@ final class MethodTest extends Framework\TestCase
         self::assertSame(Method::OPTIONS, 'OPTIONS');
         self::assertSame(Method::PATCH, 'PATCH');
         self::assertSame(Method::POST, 'POST');
-        self::assertSame(Method::PURGE, 'PURGE');
         self::assertSame(Method::PUT, 'PUT');
         self::assertSame(Method::TRACE, 'TRACE');
     }


### PR DESCRIPTION
This PR

* [x] removes the non-standard `PURGE` method from `Method`