### PR TITLE
Fix: No need to run build on PHP 7.2 twice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,10 +81,6 @@ jobs:
 
     - <<: *TEST
 
-      php: 7.2
-
-    - <<: *TEST
-
       php: 7.3
 
 notifications:


### PR DESCRIPTION
This PR

* [x] stops running a test build on PHP 7.2 twice